### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <url>https://github.com/wso2-extensions/identity-outbound-auth-windows-live.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-outbound-auth-windows-live.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-outbound-auth-windows-live.git</connection>
-        <tag>v5.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>
@@ -212,19 +212,19 @@
 
         <!-- Identity Outbound Auth Windows Live version -->
         <identity.outbound.auth.windows.live.exp.version>${project.version}</identity.outbound.auth.windows.live.exp.version>
-        <identity.outbound.auth.windows.live.imp.pkg.version.range>[5.0.0,6.0.0)</identity.outbound.auth.windows.live.imp.pkg.version.range>
+        <identity.outbound.auth.windows.live.imp.pkg.version.range>[6.0.0,7.0.0)</identity.outbound.auth.windows.live.imp.pkg.version.range>
 
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.4.7</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version.range>[4.4.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.20.142</carbon.identity.framework.version>
-        <identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</identity.framework.imp.pkg.version.range>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)</identity.framework.imp.pkg.version.range>
 
         <!-- Carbon Identity Authenticator Openid version -->
-        <identity.outbound.auth.oidc.version>5.1.3</identity.outbound.auth.oidc.version>
-        <identity.outbound.auth.oidc.imp.pkg.version.range>[5.0.0,6.0.0)</identity.outbound.auth.oidc.imp.pkg.version.range>
+        <identity.outbound.auth.oidc.version>6.0.0</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.imp.pkg.version.range>[6.0.0,7.0.0)</identity.outbound.auth.oidc.imp.pkg.version.range>
 
         <!-- Servlet API version -->
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16